### PR TITLE
web socket channel: three retries -> message buffer before ws onopen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Bump EventEmitter dependency
 * Add palava.RemotePeer.sendMessage() for custom signaling messages
 * Support DataChannels
+* Enforce right order of messages sent before the opening of the web socket
 
 
 ## 1.1.0

--- a/coffee/web_socket_channel.coffee
+++ b/coffee/web_socket_channel.coffee
@@ -50,8 +50,9 @@ class palava.WebSocketChannel extends @EventEmitter
     else # connecting ...
       if @messagesToDeliverOnConnect.length == 0
         setTimeout (=>
-          @close()
-          @emit 'not_reachable', @serverAddress if @socket.readyState != 1
+          if @socket.readyState != 1
+            @close()
+            @emit 'not_reachable', @serverAddress
         ), 5000
       @messagesToDeliverOnConnect.push(JSON.stringify(data))
 


### PR DESCRIPTION
the "three retries" fashion of handling messages before the opening of
the web socket led sometimes to reordering of messages. Now a message
buffer contains all the messages that appear before the web socket is
established and the messages of the buffer are being sent in the right order.