### PR TITLE
Add dynamic version detection

### DIFF
--- a/coffee/main.coffee.erb
+++ b/coffee/main.coffee.erb
@@ -6,10 +6,15 @@
 #= require ./room
 #= require ./session
 
+<% require 'json' %>
+
 palava = @palava
 
 palava.PROTOCOL_NAME = 'palava'
 palava.PROTOCOL_VERSION = '1.0.0'
+
+palava.LIB_VERSION = '<%= JSON.parse(File.read('package.json'))['version'] %>'
+palava.LIB_COMMIT = '<%= `git describe --long --dirty --abbrev=10 --tags` %>'
 
 palava.protocol_identifier = ->
   # palava.PROTOCOL_NAME + '.' + parseFloat(exports.PROTOCOL_VERSION)


### PR DESCRIPTION
Being able to determine the version and commit by looking at the compiled source code can be useful sometimes. Knowing the version of the library is vital for generating logs and bug reports.

I am not sure whether making the detection dynamic like this (erb parsing JSON and calling `git`) is the best idea.

    palava.LIB_VERSION
    "1.2.0-pre"
    palava.LIB_COMMIT
    "v1.1.0-34-gc19b3745f3-dirty"

The git commit format is taken from [here](http://stackoverflow.com/questions/949314/how-to-retrieve-the-hash-for-the-current-commit-in-git#comment22628764_7203521).