### PR TITLE
Separate different type of signaling errors:

### DIFF
--- a/coffee/room.coffee
+++ b/coffee/room.coffee
@@ -43,7 +43,7 @@ class palava.Room extends @EventEmitter
   #
   setupChannel: => # TODO move to session?
     @channel.on 'not_reachable',     => @emit 'signaling_not_reachable'
-    @channel.on 'error',         (e) => @emit 'signaling_error', e
+    @channel.on 'error',         (e) => @emit 'signaling_error', 'socket', e
     @channel.on 'close',         (e) => @emit 'signaling_close', e
 
   # Set default options
@@ -74,7 +74,7 @@ class palava.Room extends @EventEmitter
       newPeer = new palava.RemotePeer(msg.peer_id, msg.status, @, offers)
       @emit 'peer_joined', newPeer
 
-    @distributor.on 'error',    (msg) => @emit 'signaling_error',    msg.message
+    @distributor.on 'error',    (msg) => @emit 'signaling_error', 'server', msg.message
 
     @distributor.on 'shutdown', (msg) => @emit 'signaling_shutdown', msg.seconds
 

--- a/coffee/session.coffee
+++ b/coffee/session.coffee
@@ -132,7 +132,7 @@ class palava.Session extends @EventEmitter
     @room.on 'peer_channel_ready',      (p, n, c) => @emit 'peer_channel_ready', p, n, c
     @room.on 'signaling_shutdown',      (p) => @emit 'signaling_shutdown', p
     @room.on 'signaling_close',         (p) => @emit 'signaling_close', p
-    @room.on 'signaling_error',         (p) => @emit 'signaling_error', p
+    @room.on 'signaling_error',      (t, e) => @emit 'signaling_error', t, e
     @room.on 'signaling_not_reachable',     => @emit 'signaling_not_reachable'
     true
 

--- a/coffee/web_socket_channel.coffee
+++ b/coffee/web_socket_channel.coffee
@@ -32,13 +32,13 @@ class palava.WebSocketChannel extends @EventEmitter
       try
         @emit 'message', JSON.parse(msg.data)
       catch SyntaxError
-        @emit 'error_invalid_json', msg
+        @emit 'error', 'invalid_json', msg
     @socket.onerror = (msg) =>
       if @retries > 0
         @retries -= 1
         @setupWebsocket()
       else
-        @emit 'error', msg
+        @emit 'error', 'socket', msg
     @socket.onclose = =>
       @emit 'close'
 


### PR DESCRIPTION
- socket: WebSocket implementation of browser throws error for some reason
- invalid_json: The message sent by signaling server is not well-formed
- server: The server decided to send an error event