### PR TITLE
Refactor session initiation

### DIFF
--- a/coffee/gum.coffee
+++ b/coffee/gum.coffee
@@ -29,7 +29,6 @@ class palava.Gum extends @EventEmitter
       (error) =>
         @emit 'stream_error', error
     )
-    true
 
   getStream: =>
     @stream


### PR DESCRIPTION
- Automatically join room when user media ready. Before, this was left to the library
  user who had to know, to trigger the join function in the local_stream ready event
- Session#init renamed to Session#connect to highlight API change
- Adapt reconnect to not only leave room, but also join the room again
- Flatten options in session initializer functions (no options in options)
- Add userMediaConfig option, so no empty identity needs to be created
- dromedaryCase (instead of snake_case) for webSocketAddress option
- Gum#request_stream() returns the promise instead of always returning true

After having simplified session creation, some implicit bugs that were present in the old implementation were gone