### PR TITLE
Room#leave() improvements

### DIFF
--- a/coffee/room.coffee
+++ b/coffee/room.coffee
@@ -84,8 +84,8 @@ class palava.Room extends @EventEmitter
   #
   join: (status = {}) =>
     @joinCheckTimeout = setTimeout ( =>
-      @emit 'join_error', 'Not able to join room'
-      @leave() # TODO ?
+      @emit 'join_error'
+      @leave()
     ), @options.joinTimeout
 
     @options.ownStatus[key] = status[key] for key in status
@@ -99,12 +99,10 @@ class palava.Room extends @EventEmitter
   # Leave the room
   #
   leave: =>
-    @emit 'leave'
     if @channel
       @distributor.send
         event: 'leave_room'
-      @channel.close()
-    @localPeer && @localPeer.stream && @localPeer.stream.close()
+    @emit 'left'
 
   # Find peer with the given id
   #

--- a/coffee/session.coffee
+++ b/coffee/session.coffee
@@ -142,9 +142,10 @@ class palava.Session extends @EventEmitter
     @room.on 'local_stream_ready',      (s) => @emit 'local_stream_ready', s
     @room.on 'local_stream_error',      (e) => @emit 'local_stream_error', e
     @room.on 'local_stream_removed',        => @emit 'local_stream_removed'
-    @room.on 'join_error',              (e) => @emit 'room_join_error', @room, e
+    @room.on 'join_error',                  => @emit 'room_join_error', @room
     @room.on 'full',                        => @emit 'room_full',       @room
     @room.on 'joined',                      => @emit 'room_joined',     @room
+    @room.on 'left',                        => @emit 'room_left',       @room
     @room.on 'peer_joined',             (p) => @emit 'peer_joined', p
     @room.on 'peer_offer',              (p) => @emit 'peer_offer', p
     @room.on 'peer_answer',             (p) => @emit 'peer_answer', p


### PR DESCRIPTION
- Do not close channel / release user media (not room related, will be done somewhere else)
- Rename room left event and correctly pass to session
- No need to call leave when join not possible