### PR TITLE
Add TURN support

### DIFF
--- a/coffee/remote_peer.coffee
+++ b/coffee/remote_peer.coffee
@@ -29,6 +29,7 @@ class palava.RemotePeer extends palava.Peer
     @setupPeerConnection(offers)
     @setupDistributor()
 
+    @offers = offers
     if offers
       @sendOffer()
 
@@ -52,11 +53,11 @@ class palava.RemotePeer extends palava.Peer
     options = []
     if @room.options.stun
       options.push({urls: [@room.options.stun]})
-    if @room.options.turn
+    if @room.options.turn && @turnCredentials
       options.push
-        urls: [@room.options.turn.url]
-        username: @room.options.turn.username
-        credential: @room.options.turn.password
+        urls: [@room.options.turn]
+        username: @turnCredentials.user
+        credential: @turnCredentials.password
     {iceServers: options}
 
   # Sets up the peer connection and its events
@@ -131,6 +132,21 @@ class palava.RemotePeer extends palava.Peer
           registerChannel(event.channel)
 
     @peerConnection
+
+  # Check if turn was already tried as (last) connection option
+  #
+  # @return [Boolean] true if turn was tried by using the tryTurn function
+  #
+  hasTriedTurn: => !!@turnCredentials
+
+  # Check if turn was already tried as (last) connection option
+  #
+  # @return [Object] true if turn was tried by using the tryTurn function
+  #
+  tryTurn: (credentials) =>
+    @closePeerConnection()
+    @turnCredentials = credentials
+    @setupPeerConnection(@offers)
 
   # Sets up the distributor connecting to the participant
   #

--- a/coffee/room.coffee
+++ b/coffee/room.coffee
@@ -58,7 +58,7 @@ class palava.Room extends @EventEmitter
       for peer in msg.peers
         offers = !palava.browser.isChrome()
         newPeer = new palava.RemotePeer(peer.peer_id, peer.status, @, offers)
-      @emit "joined", @
+      @emit "joined", msg.own_id, msg.turn_user, msg.turn_password
 
     @distributor.on 'new_peer', (msg) =>
       offers = msg.status.user_agent == 'chrome'

--- a/coffee/room.coffee
+++ b/coffee/room.coffee
@@ -58,7 +58,11 @@ class palava.Room extends @EventEmitter
       for peer in msg.peers
         offers = !palava.browser.isChrome()
         newPeer = new palava.RemotePeer(peer.peer_id, peer.status, @, offers)
-      @emit "joined", msg.own_id, msg.turn_user, msg.turn_password
+      if msg.turn_user
+        turnCredentials = { user: msg.turn_user, password: msg.turn_password }
+      else
+        turnCredentials = null
+      @emit "joined", msg.own_id, turnCredentials
 
     @distributor.on 'new_peer', (msg) =>
       offers = msg.status.user_agent == 'chrome'

--- a/coffee/room.coffee
+++ b/coffee/room.coffee
@@ -44,6 +44,7 @@ class palava.Room extends @EventEmitter
   setupOptions: =>
     @options.joinTimeout ||= 1000
     @options.ownStatus ||= {}
+    @options.filterIceCandidateTypes ||= []
 
   # Initialize global distributor and messaging
   #
@@ -54,15 +55,15 @@ class palava.Room extends @EventEmitter
 
     @distributor.on 'joined_room', (msg) =>
       clearTimeout(@joinCheckTimeout)
-      new palava.LocalPeer(msg.own_id, @options.ownStatus, @)
-      for peer in msg.peers
-        offers = !palava.browser.isChrome()
-        newPeer = new palava.RemotePeer(peer.peer_id, peer.status, @, offers)
       if msg.turn_user
         turnCredentials = { user: msg.turn_user, password: msg.turn_password }
       else
         turnCredentials = null
-      @emit "joined", msg.own_id, turnCredentials
+      new palava.LocalPeer(msg.own_id, @options.ownStatus, @)
+      for peer in msg.peers
+        offers = !palava.browser.isChrome()
+        newPeer = new palava.RemotePeer(peer.peer_id, peer.status, @, offers, turnCredentials)
+      @emit "joined"
 
     @distributor.on 'new_peer', (msg) =>
       offers = msg.status.user_agent == 'chrome'

--- a/coffee/session.coffee
+++ b/coffee/session.coffee
@@ -158,7 +158,11 @@ class palava.Session extends @EventEmitter
       @tearDown(true)
       @emit 'room_join_error', @room
     @room.on 'full',                        => @emit 'room_full',       @room
-    @room.on 'joined',                      => @emit 'room_joined',     @room
+    @room.on 'joined',               (u, p) =>
+      @turnCredentials =
+        user: tu
+        password: tpw
+      @emit 'room_joined', @room
     @room.on 'left',                        => @emit 'room_left',       @room
     @room.on 'peer_joined',             (p) => @emit 'peer_joined', p
     @room.on 'peer_offer',              (p) => @emit 'peer_offer', p
@@ -168,7 +172,11 @@ class palava.Session extends @EventEmitter
     @room.on 'peer_stream_removed',     (p) => @emit 'peer_stream_removed', p
     @room.on 'peer_connection_pending',      (p) => @emit 'peer_connection_pending', p
     @room.on 'peer_connection_established',  (p) => @emit 'peer_connection_established', p
-    @room.on 'peer_connection_failed',       (p) => @emit 'peer_connection_failed', p
+    @room.on 'peer_connection_failed',       (p) =>
+      if !p.hasTriedTurn && @turnCredentials
+        p.tryTurn @turnCredentials
+      else
+        @emit 'peer_connection_failed', p
     @room.on 'peer_connection_disconnected', (p) => @emit 'peer_connection_disconnected', p
     @room.on 'peer_connection_closed',       (p) => @emit 'peer_connection_closed', p
     @room.on 'peer_left',               (p) => @emit 'peer_left', p

--- a/coffee/session.coffee
+++ b/coffee/session.coffee
@@ -158,10 +158,8 @@ class palava.Session extends @EventEmitter
       @tearDown(true)
       @emit 'room_join_error', @room
     @room.on 'full',                        => @emit 'room_full',       @room
-    @room.on 'joined',               (u, p) =>
-      @turnCredentials =
-        user: tu
-        password: tpw
+    @room.on 'joined', (ownId, turnCredentials) =>
+      @turnCredentials = turnCredentials
       @emit 'room_joined', @room
     @room.on 'left',                        => @emit 'room_left',       @room
     @room.on 'peer_joined',             (p) => @emit 'peer_joined', p
@@ -172,9 +170,9 @@ class palava.Session extends @EventEmitter
     @room.on 'peer_stream_removed',     (p) => @emit 'peer_stream_removed', p
     @room.on 'peer_connection_pending',      (p) => @emit 'peer_connection_pending', p
     @room.on 'peer_connection_established',  (p) => @emit 'peer_connection_established', p
-    @room.on 'peer_connection_failed',       (p) =>
-      if !p.hasTriedTurn && @turnCredentials
-        p.tryTurn @turnCredentials
+    @room.on 'peer_connection_failed', (peer) =>
+      if !peer.hasTriedTurn && @turnCredentials
+        peer.tryTurn @turnCredentials
       else
         @emit 'peer_connection_failed', p
     @room.on 'peer_connection_disconnected', (p) => @emit 'peer_connection_disconnected', p


### PR DESCRIPTION
The client receives a turn login on room join if the server supports TURN.
It first tries a connection via stun. If that fails, it tries again with
turn using the received login.